### PR TITLE
add h1, navigation is right-justified

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@
     <body>
         <div data-role="page" id="mainPage">
             <div role="main" class="ui-content">
-            <div id="nav">
+            <h1 class="col-md-4 h4">23区保育園マップβ版 by Code for Tokyo</h1>
+            <div id="nav" class="col-md-8 text-right">
                 <fieldset id="nav1" data-role="controlgroup" data-type="horizontal" data-mini="true">
                     <label for="cbNinka" id="lblNinka">認可</label>
                     <input type="checkbox" name="cbNinka" id="cbNinka" checked="checked">


### PR DESCRIPTION
「左上にタイトルを入れる」というissue #9 を見かけたので、勝手ながら追加してみました。

タイトルは「23区保育園マップ」「Tokyo保育園マップ」「東京保育園マップ」のどれがよいか分からなかったのですが、HTML内のtitle要素に合わせています。適宜変更していただければ。
また、タイトルが左側に来たので、ナビゲーションは右寄せにしています。
